### PR TITLE
Fix HPKP pins verification

### DIFF
--- a/src/AGCertificateVerifier.cpp
+++ b/src/AGCertificateVerifier.cpp
@@ -192,8 +192,8 @@ AGVerifyResult AGCertificateVerifier::verifyDNSName(const std::string &dnsName, 
  * are allowed to use SHA1).
  *
  * @param store CA store
- * @param dnsName Host name
  * @param certChain Certificate chain
+ * @param dnsName Host name
  * @param basicCheckOnly Don't perforn sha1 deprecation and HPKP checks
  * @return Verify result
  */

--- a/src/AGCertificateVerifier.h
+++ b/src/AGCertificateVerifier.h
@@ -274,9 +274,10 @@ private:
 
     AGVerifyResult verifyDNSName(const std::string &dnsName, STACK_OF(X509) *certChain);
 
-    AGVerifyResult verifyChain(X509_STORE *store, STACK_OF(X509) *certChain);
+    AGVerifyResult verifyChain(X509_STORE *store, STACK_OF(X509) *certChain,
+                               const std::string &dnsName, bool basicCheckOnly);
 
-    AGVerifyResult verifyHttpPublicKeyPins(const std::string &dnsName, STACK_OF(X509) *certChain);
+    AGVerifyResult verifyHttpPublicKeyPins(const std::string &dnsName, X509_STORE_CTX *ctx);
 
     AGVerifyResult verifyCrlSetsStatus(STACK_OF(X509) *certChain);
 

--- a/src/AGHPKPInfo.cpp
+++ b/src/AGHPKPInfo.cpp
@@ -73,7 +73,8 @@ bool AGHPKPInfo::hasPinsInChain(STACK_OF(X509) *certChain) const {
         uint8_t hash[32];
         uint32_t hash_len;
         ASN1_item_digest(ASN1_ITEM_rptr(X509_PUBKEY), EVP_sha256(), X509_get_X509_PUBKEY(cert), hash, &hash_len);
-        if (pkPins.count(AGStringUtils::encodeToBase64(hash, hash_len))) {
+        std::string spkiHash = AGStringUtils::encodeToBase64(hash, hash_len);
+        if (pkPins.count(spkiHash)) {
             return true;
         }
     }

--- a/test/AGCertificateVerifierTest.cpp
+++ b/test/AGCertificateVerifierTest.cpp
@@ -40,6 +40,7 @@ struct TestParam {
 TestParam tests[] = {
         {"www.google.com", AGVerifyResult::OK},
         {"badssl.com", AGVerifyResult::OK},
+        {"twitter.com", AGVerifyResult::OK},
         {"expired.badssl.com", AGVerifyResult::EXPIRED},
         {"wrong.host.badssl.com", AGVerifyResult::HOST_NAME_MISMATCH},
         {"self-signed.badssl.com", AGVerifyResult::SELF_SIGNED},


### PR DESCRIPTION
Fixes #8.

The problem was that HPKP pins check performed on chain provided by server, not on complete chain.